### PR TITLE
Fixes

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -x
+set -ex
 
 . cico_utils/setup_utils.sh
 . ./constants.sh

--- a/constants.sh
+++ b/constants.sh
@@ -13,7 +13,7 @@ SUPPORTED_NODE_VERSIONS=(
 OS=(
 	"fedora"
 	"centos"
-	"unix"
+	"rhel"
 )
 
 DEFAULT_PORT=9090
@@ -29,7 +29,7 @@ DEFAULT_PULL_REGISTRY=registry.devshift.net
 DEFAULT_ORGANIZATION=fabric8-hdd
 # DEFAULT_OS_REGISTRY=registry.access.redhat.com/rhel7
 DEFAULT_OS_REGISTRY=${DEFAULT_APP_REGISTRY}
-BUILD_MACHINE_OS="centos"
+BUILD_MACHINE_OS=$(echo `cat /etc/*-release | grep -i "^id=" | cut -d'=' -f 2` | tr -d '"' | tr '[:upper:]' '[:lower:]')
 # Expected as ENV vars in build machines
 # SUBSCRIPTION_USERNAME=""
 # SUBSCRIPTION_PASSWORD=""


### PR DESCRIPTION
This PR fixes the following:
1. Fail fast: Fail cico build script on first failure in any intermediate step
2. Add rhel to supported os list and hence fix the os infra test in case of rhel
3. Auto detect build machine os instead of having to put it explicitly in constants.sh

Signed-off-by: anmolbabu <anmolbudugutta@gmail.com>